### PR TITLE
drop down to use aws s3 sync instead of travis' s3 deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,8 @@ install:
 script: ./build.sh
 
 deploy:
-  - provider: s3
-    access_key_id: $AWS_ACCESS_KEY_ID
-    secret_access_key: $AWS_SECRET_ACCESS_KEY
-    local_dir: public/
-    bucket: "ops.laps.run"
+  - provider: script
+    script: aws s3 sync --size-only public/ ops.laps.run
     skip_cleanup: true
     on:
       repo: lapsrun/ops.laps.run


### PR DESCRIPTION
s3 deploy uses cp and will blindly copy files even if they already exist. puts and posts cost $.005 per 1000 requests and these blind cp commands will add up.